### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/AspNetCore.ApiGateway.Tests/AspNetCore.ApiGateway.Tests.csproj
+++ b/AspNetCore.ApiGateway.Tests/AspNetCore.ApiGateway.Tests.csproj
@@ -9,11 +9,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="coverlet.collector" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi@VeritasSoftware, I found an issue in the AspNetCore.ApiGateway.Tests.csproj:

Packages Microsoft.AspNetCore.TestHost v3.0.0, Microsoft.NET.Test.Sdk v16.2.0, xunit v2.4.0, xunit.runner.visualstudio v2.4.0 and coverlet.collector v1.0.1 transitively introduce 123 dependencies into AspNetCore.ApiGateway’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/AspNetCore-ApiGateway.html)), while Microsoft.AspNetCore.TestHost v3.1.3, Microsoft.NET.Test.Sdk v16.6.0, xunit v2.4.1, xunit.runner.visualstudio v2.4.1 and coverlet.collector v1.1.0 can only introduce 78 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/AspNetCore-ApiGateway_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose